### PR TITLE
Fix argument passing to slimerjs and casperjs

### DIFF
--- a/slimerjs/Dockerfile
+++ b/slimerjs/Dockerfile
@@ -27,11 +27,11 @@ RUN \
   tar -xjf /tmp/slimerjs-$SLIMERJS_VERSION_F-linux-x86_64.tar.bz2 -C /tmp && \
   rm -f /tmp/slimerjs-$SLIMERJS_VERSION_F-linux-x86_64.tar.bz2 && \
   mv /tmp/slimerjs-$SLIMERJS_VERSION_F/ /srv/var/slimerjs && \
-  echo '#!/bin/bash\nxvfb-run /srv/var/slimerjs/slimerjs $*' > /srv/var/slimerjs/slimerjs.sh && \
+  echo '#!/bin/bash\nxvfb-run /srv/var/slimerjs/slimerjs "$@"' > /srv/var/slimerjs/slimerjs.sh && \
   chmod 755 /srv/var/slimerjs/slimerjs.sh && \
   ln -s /srv/var/slimerjs/slimerjs.sh /usr/bin/slimerjs && \
   git clone https://github.com/n1k0/casperjs.git /srv/var/casperjs && \
-  echo '#!/bin/bash\n/srv/var/casperjs/bin/casperjs --engine=slimerjs $*' >> /srv/var/casperjs/casperjs.sh && \
+  echo '#!/bin/bash\n/srv/var/casperjs/bin/casperjs --engine=slimerjs "$@"' >> /srv/var/casperjs/casperjs.sh && \
   chmod 755 /srv/var/casperjs/casperjs.sh && \
   ln -s /srv/var/casperjs/casperjs.sh /usr/bin/casperjs && \
   apt-get autoremove -y && \


### PR DESCRIPTION
This change correctly orders empty arguments and arguments with spaces. e.g.

```shell
docker run -v /scripts:/scripts cmfaith/slimerjs /scripts/script.js one two "" "f o u r"
```

Currently you get the following `phantom.args`, which is incorrect:

```javascript
['one', 'two', 'f', 'o', 'u', 'r']
``` 

This change ensures that `phantom.args` is the following:

```javascript
['one', 'two', '', 'f o u r']
```